### PR TITLE
Refactor and enhance tests, improve AWS configurations, and update Me…

### DIFF
--- a/applications/app-service/src/main/java/co/com/pragma/ReportServiceApplication.java
+++ b/applications/app-service/src/main/java/co/com/pragma/ReportServiceApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-public class MainApplication {
+public class ReportServiceApplication {
     public static void main(String[] args) {
-        SpringApplication.run(MainApplication.class, args);
+        SpringApplication.run(ReportServiceApplication.class, args);
     }
 }

--- a/applications/app-service/src/main/resources/application-aws.yaml
+++ b/applications/app-service/src/main/resources/application-aws.yaml
@@ -1,6 +1,6 @@
 aws:
   dynamodb:
-    endpoint: "${AWS_DYNAMO_ENDPOINT:http://localhost:8000}"
+    endpoint: "${AWS_DYNAMO_ENDPOINT:https://dynamodb.us-east-1.amazonaws.com}"
 entrypoint:
   sqs:
     endpoint: "${AWS_SQS_REPORT_ENDPOINT:https://sqs.us-east-1.amazonaws.com}"

--- a/domain/model/src/main/java/co/com/pragma/model/constants/Metrics.java
+++ b/domain/model/src/main/java/co/com/pragma/model/constants/Metrics.java
@@ -6,4 +6,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Metrics {
     public static final String QUANTITY_METRIC = "quantity";
+    public static final String AMOUNT_METRIC = "amount";
 }

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/metric/MetricUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/metric/MetricUseCase.java
@@ -9,6 +9,7 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 
+import static co.com.pragma.model.constants.Metrics.AMOUNT_METRIC;
 import static co.com.pragma.model.constants.Metrics.QUANTITY_METRIC;
 
 @RequiredArgsConstructor
@@ -36,6 +37,7 @@ public class MetricUseCase {
     private Mono<String> validateMetricName(String name) {
         if (name == null || name.isBlank()) return Mono.error(new InvalidPathVariableException());
         if (name.equals(QUANTITY_METRIC)) return Mono.just(name);
+        if (name.equals(AMOUNT_METRIC)) return Mono.just(name);
         return Mono.error(new InvalidPathVariableException());
     }
 }

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/helper/TemplateAdapterOperations.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/helper/TemplateAdapterOperations.java
@@ -65,19 +65,6 @@ public abstract class TemplateAdapterOperations<E, K, V> {
         return listOfModel(pagePublisher);
     }
 
-    /**
-     * @return Mono<List < E>>
-     * @implNote Bancolombia does not suggest the Scan function for DynamoDB tables due to the low performance resulting
-     * from the design of the database engine (Key value). Optimize the query using Query, GetItem or BatchGetItem
-     * functions, and if necessary, consider the Single-Table Design pattern for DynamoDB.
-     * @deprecated
-     */
-    @Deprecated(forRemoval = true)
-    public Mono<List<E>> scan() {
-        PagePublisher<V> pagePublisher = table.scan();
-        return listOfModel(pagePublisher);
-    }
-
     private Mono<List<E>> listOfModel(PagePublisher<V> pagePublisher) {
         return Mono.from(pagePublisher).map(page -> page.items().stream().map(this::toModel).toList());
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/Handler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/Handler.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class Handler {
 
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     private final MetricUseCase metricUseCase;
     private final MetricMapper metricMapper;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/RouterRest.java
@@ -46,7 +46,7 @@ public class RouterRest {
                                             description = METRIC_NAME_DESC,
                                             required = true,
                                             example = Metrics.QUANTITY_METRIC,
-                                            schema = @Schema(type = "string", allowableValues = {Metrics.QUANTITY_METRIC})
+                                            schema = @Schema(type = "string", allowableValues = {Metrics.QUANTITY_METRIC, Metrics.AMOUNT_METRIC})
                                     )
                             },
                             responses = {

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/sqs/listener/SQSProcessor.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/sqs/listener/SQSProcessor.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 @Service
 @RequiredArgsConstructor
 public class SQSProcessor implements Function<Message, Mono<Void>> {
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     private final MetricUseCase metricUseCase;
     private final LoggerPort logger;
     private final ObjectMapper objectMapper;

--- a/infrastructure/helpers/metrics/src/test/java/co/com/pragma/metrics/aws/MicrometerMetricPublisherTest.java
+++ b/infrastructure/helpers/metrics/src/test/java/co/com/pragma/metrics/aws/MicrometerMetricPublisherTest.java
@@ -3,10 +3,13 @@ package co.com.pragma.metrics.aws;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.metrics.internal.EmptyMetricCollection;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ExtendWith(MockitoExtension.class)
 class MicrometerMetricPublisherTest {
 
     @Test

--- a/main.gradle
+++ b/main.gradle
@@ -56,7 +56,7 @@ subprojects {
 
     pitest {
         targetClasses = ['co.com.pragma.*']
-        excludedClasses = []
+        excludedClasses = ['co.com.pragma.metrics.aws.MicrometerMetricPublisher']
         excludedTestClasses = []
         pitestVersion = '1.20.1'
         verbose = false
@@ -100,6 +100,11 @@ tasks.register('jacocoMergedReport', JacocoReport) {
         csv.setRequired false
         html.setRequired true
     }
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: [
+                'co/com/pragma/metrics/aws/MicrometerMetricPublisher.class'
+        ])
+    }))
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
This pull request introduces several improvements and updates across the codebase, primarily focused on extending metric support, enhancing AWS integration, improving test coverage, and refining configuration and code quality. The most significant changes are grouped below by theme.

**Metric Support Enhancements**

* Added support for a new metric type, `amount`, by introducing `AMOUNT_METRIC` in `Metrics.java`, updating validation logic in `MetricUseCase.java`, and allowing it as a valid API parameter. This enables the system to handle both quantity and amount metrics. [[1]](diffhunk://#diff-97a12c41afc768330175005dc1c984fb2663afb38a341a98f857348d8db4310bR9) [[2]](diffhunk://#diff-b5fbb5b6436ea43392bd3bc642593eaed74ca3cfc888f4d1a6629901077b98beR12) [[3]](diffhunk://#diff-b5fbb5b6436ea43392bd3bc642593eaed74ca3cfc888f4d1a6629901077b98beR40) [[4]](diffhunk://#diff-d500273ba1e41b0042c9750a80ea4c49651271e61bda8437be3a61d4469b61f3L49-R49)

**AWS Integration and Configuration**

* Updated the default DynamoDB endpoint to use the production AWS endpoint instead of localhost, ensuring the application is configured for cloud environments by default.
* Renamed the main application class from `MainApplication` to `ReportServiceApplication` for clearer intent and consistency.

**Testing Improvements**

* Added comprehensive tests for DynamoDB query operations in `TemplateAdapterOperationsTest.java`, including both standard queries and index-based queries, increasing test coverage and reliability.
* Added new tests in `SQSListenerTest.java` to verify correct logging behavior for both intentional shutdowns (InterruptedException) and unexpected errors, improving observability and robustness of the SQS listener.
* Applied `@ExtendWith(MockitoExtension.class)` to `MicrometerMetricPublisherTest` for improved test setup and isolation.

**Code Quality and Configuration**

* Suppressed Spring autowiring warnings in handler and SQS processor classes for cleaner code and to avoid unnecessary IDE warnings. [[1]](diffhunk://#diff-30a1c71b2c4e945bb0fc4ff31717f20a1a254d569f9af70d81da6de8c223c3feR16) [[2]](diffhunk://#diff-5f2bf08e76488f570fef1abcbe845d9e99f2bdef834535ebb9984534b8cfd407R20)
* Excluded `MicrometerMetricPublisher` from PIT mutation testing and Jacoco coverage reports to focus coverage metrics on relevant production code. [[1]](diffhunk://#diff-0bf868ffe3d91498a1e074fb9d3bfabf549e604f42094f7c608e78db2f3cf6bdL59-R59) [[2]](diffhunk://#diff-0bf868ffe3d91498a1e074fb9d3bfabf549e604f42094f7c608e78db2f3cf6bdR103-R107)

**Code Cleanup**

* Removed the deprecated and unused `scan()` method from `TemplateAdapterOperations.java` to reduce technical debt.

These changes collectively improve the system's metric flexibility, AWS readiness, test reliability, and maintainability.