### PR TITLE
HU 10

### DIFF
--- a/applications/app-service/src/main/resources/application-aws.yaml
+++ b/applications/app-service/src/main/resources/application-aws.yaml
@@ -5,3 +5,13 @@ entrypoint:
   sqs:
     endpoint: "${AWS_SQS_REPORT_ENDPOINT:https://sqs.us-east-1.amazonaws.com}"
     queueUrl: "${AWS_SQS_REPORT_URL:https://sqs.us-east-1.amazonaws.com/096187159240/solicitude-report-queue}"
+security:
+  jwt:
+    secret: ${JWT_SECRET:iBdGbA8Dxowf12Zs7IYH91+KwKOg5yb39RGQv6pOWes=}
+cors:
+  allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8083}"
+
+logging:
+  level:
+    root: INFO
+    co.com.pragma: DEBUG

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -5,3 +5,13 @@ entrypoint:
   sqs:
     endpoint: "${AWS_SQS_REPORT_ENDPOINT:http://localhost:4566}"
     queueUrl: "${AWS_SQS_REPORT_URL:http://localhost:4566/000000000000/solicitude-report-queue}"
+security:
+  jwt:
+    secret: ${JWT_SECRET:iBdGbA8Dxowf12Zs7IYH91+KwKOg5yb39RGQv6pOWes=}
+cors:
+  allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8083}"
+
+logging:
+  level:
+    root: INFO
+    co.com.pragma: DEBUG

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -1,0 +1,13 @@
+aws:
+  dynamodb:
+    endpoint: "${AWS_DYNAMO_ENDPOINT}"
+entrypoint:
+  sqs:
+    endpoint: "${AWS_SQS_REPORT_ENDPOINT}"
+    queueUrl: "${AWS_SQS_REPORT_URL}"
+security:
+  jwt:
+    secret: ${JWT_SECRET}
+
+cors:
+  allowed-origins: "${CORS_ALLOWED_ORIGINS}"

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -6,13 +6,13 @@ spring:
   devtools:
     add-properties: false
     restart:
-      enabled: false # Disable automatic restarts to prevent premature context closure
+      enabled: false
   h2:
     console:
       enabled: true
       path: "/h2"
   profiles:
-    active: "${SPRING_PROFILES_ACTIVE:aws}"
+    active: "${SPRING_PROFILES_ACTIVE:local}"
 aws:
   dynamodb:
     endpoint: "${AWS_DYNAMO_ENDPOINT:http://localhost:8000}"
@@ -27,7 +27,7 @@ management:
       probes:
         enabled: true
 cors:
-  allowed-origins: "http://localhost:4200,http://localhost:8083"
+  allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8083}"
 entrypoint:
   sqs:
     region: "${ADAPTERS_SQS_REGION:us-east-1}"
@@ -40,10 +40,5 @@ entrypoint:
 
 security:
   jwt:
-    secret: ${JWT_SECRET:6wmLjTUj5h4CXtp23BPjlr2IouInKGEBhqVi+LkR1KlIisuE4dKm4vbwWhUKwPsg53CjqX5Uu2L8TshpLXPdWA==}
+    secret: ${JWT_SECRET}
     expiration: 3600
-
-logging:
-  level:
-    root: INFO
-    co.com.pragma: DEBUG

--- a/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/dynamodb/config/DynamoDBConfigTest.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/test/java/co/com/pragma/dynamodb/config/DynamoDBConfigTest.java
@@ -24,7 +24,7 @@ class DynamoDBConfigTest {
     @Test
     void testAmazonDynamoDB() {
 
-        DynamoDbAsyncClient result = dynamoDBConfig.amazonDynamoDB(
+        DynamoDbAsyncClient result = dynamoDBConfig.awsAmazonDynamoDB(
                 "http://aws.dynamo.test",
                 "region",
                 publisher);

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -50,6 +50,14 @@ public class WebSecurityConfig {
                                 ApiConstants.ApiPaths.SWAGGER_PATH
                         ).permitAll()
                         .pathMatchers(
+                                ApiPathMatchers.HEALTH_CHECK_MATCHER
+                        ).permitAll()
+                        .pathMatchers(
+                                ApiPathMatchers.ACTUATOR_MATCHER
+                        ).hasAnyAuthority(
+                                ApiConstants.Role.SUPER_USER_ROLE_NAME
+                        )
+                        .pathMatchers(
                                 HttpMethod.GET, ApiPathMatchers.REPORT_MATCHER
                         ).hasAnyAuthority(
                                 ApiConstants.Role.ADMIN_ROLE_NAME

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -31,12 +31,16 @@ public class ApiConstants {
         //PERMIT ALL
         public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
         public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        //SUPER_USER
+        public static final String ACTUATOR_MATCHER = "/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
         //ADMIN
         public static final String REPORT_MATCHER = ApiPaths.REPORT_PATH +"/**";
     }
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class Role {
+        public static final String SUPER_USER_ROLE_NAME = "SUPER_USER";
         public static final String CLIENT_ROLE_NAME = "CLIENTE";
         public static final String ADMIN_ROLE_NAME = "ADMIN";
         public static final String ADVISOR_ROLE_NAME = "ASESOR";

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/sqs/listener/config/SQSConfig.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/sqs/listener/config/SQSConfig.java
@@ -4,13 +4,16 @@ import co.com.pragma.model.logs.gateways.LoggerPort;
 import co.com.pragma.sqs.listener.helper.SQSListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import reactor.core.publisher.Mono;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
@@ -34,7 +37,19 @@ public class SQSConfig {
     }
 
     @Bean
-    public SqsAsyncClient configSqs(SQSProperties properties, MetricPublisher publisher) {
+    @Profile("local")
+    public SqsAsyncClient localSqsAsyncClient(SQSProperties properties, MetricPublisher publisher) {
+        return SqsAsyncClient.builder()
+                .endpointOverride(resolveEndpoint(properties))
+                .region(Region.of(properties.region()))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+                .build();
+    }
+
+    @Bean
+    @Profile("!local")
+    public SqsAsyncClient awsSqsAsyncClient(SQSProperties properties, MetricPublisher publisher) {
         return SqsAsyncClient.builder()
                 .endpointOverride(resolveEndpoint(properties))
                 .region(Region.of(properties.region()))

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/sqs/listener/config/SQSConfigTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/sqs/listener/config/SQSConfigTest.java
@@ -45,14 +45,14 @@ class SQSConfigTest {
     @Test
     void configSqsIsNotNull() {
         var loggingMetricPublisher = LoggingMetricPublisher.create();
-        assertThat(sqsConfig.configSqs(sqsProperties, loggingMetricPublisher)).isNotNull();
+        assertThat(sqsConfig.awsSqsAsyncClient(sqsProperties, loggingMetricPublisher)).isNotNull();
     }
 
     @Test
     void configSqsWhenEndpointIsNotNull() {
         var loggingMetricPublisher = LoggingMetricPublisher.create();
         when(sqsProperties.endpoint()).thenReturn("http://localhost:4566");
-        assertThat(sqsConfig.configSqs(sqsProperties, loggingMetricPublisher)).isNotNull();
+        assertThat(sqsConfig.awsSqsAsyncClient(sqsProperties, loggingMetricPublisher)).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces several configuration and security improvements across multiple environments, focusing on making environment variables more flexible, refining AWS client bean initialization, and updating security access controls. The changes enhance environment-specific setups, improve security role management, and ensure proper bean instantiation for AWS services in both local and production environments.

**Configuration improvements:**

* Made `cors.allowed-origins` and `security.jwt.secret` configurable via environment variables in all `application-*.yaml` files, allowing for greater flexibility across environments. [[1]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948L30-R30) [[2]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948L43-L49) [[3]](diffhunk://#diff-998f42cb3d9ab2e77809f155bd5c1402bfd82dc935a154b95b7c64525cf9ec99R8-R17) [[4]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3R8-R17) [[5]](diffhunk://#diff-2aa382a3982f48798410bab12030ebaa4c9fc637bad08ac2a707c3dd2299aa37R1-R13)
* Changed the default Spring profile from `aws` to `local` in `application.yaml`, making local development the default.

**AWS client initialization enhancements:**

* Refactored DynamoDB client beans in `DynamoDBConfig.java` to use separate beans for `local` and `aws` profiles, ensuring correct credentials and endpoint usage per environment. Also, changed the production bean to use the `prod` profile. [[1]](diffhunk://#diff-8b9438fad867955e25d049f3a894ba86da57c7e0548522e8cba39288ca050cebL22-R36) [[2]](diffhunk://#diff-8b9438fad867955e25d049f3a894ba86da57c7e0548522e8cba39288ca050cebL35-R48)
* Updated SQS client bean creation in `SQSConfig.java` to provide distinct beans for `local` (using dummy credentials) and non-local environments, improving clarity and correctness of AWS credentials handling. [[1]](diffhunk://#diff-39719a2d3d86571983bc5cd02c32c5e2264c1b055507b0678695b5660e017f5bR7-R16) [[2]](diffhunk://#diff-39719a2d3d86571983bc5cd02c32c5e2264c1b055507b0678695b5660e017f5bL37-R52)

**Security and access control updates:**

* Added new path matchers and roles to `ApiConstants.java`, introducing `SUPER_USER` and restricting `/actuator/**` endpoints to this role, while allowing health checks and API docs for all. [[1]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8R34-R43) [[2]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32R52-R59)

**Test adjustments:**

* Updated tests in `DynamoDBConfigTest.java` and `SQSConfigTest.java` to reflect the new bean names and initialization logic. [[1]](diffhunk://#diff-6825c4ce5c7c60d936af769f183a3179792597279d0cb20f861970e0012d7127L27-R27) [[2]](diffhunk://#diff-8534778bdb4a011d730bd8df757fcb479ac98f87921057cca45d3523b7584dd1L48-R55)