### PR TITLE
Hu/10 deploy producction

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -37,17 +37,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.ECR_REPOSITORY }}
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}
           tags: | 
             type=semver,pattern={{version}}
             type=raw,value=latest
 
       - name: Build and push Docker image
-        env:
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_NAME }}
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ./deployment/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building and pushing Docker images to Amazon ECR whenever a new version tag is pushed. This streamlines the deployment process by integrating Docker image creation and publishing directly into the CI/CD pipeline.

**Deployment automation:**

* Added a `.github/workflows/deploy-to-ecr.yml` workflow that triggers on new version tags (`v*.*.*`) to build and push Docker images to Amazon ECR using GitHub Actions, with steps for AWS authentication, Docker setup, and image metadata management.