### PR TITLE
Update workflows to support public ECR registry configuration

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Log in to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,8 +39,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}
-          tags: | 
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
+          tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to Amazon ECR, making it compatible with Amazon ECR Public registries. The main changes involve configuring the login step to use the public registry and updating the image path to include the public alias.

**Amazon ECR Public registry support:**

* Added the `registry-type: public` parameter to the ECR login step in `.github/workflows/deploy-to-ecr.yml` to enable login to Amazon ECR Public.
* Updated the `images` field in the Docker metadata action to use the public registry alias (`ECR_PUBLIC_ALIAS`) in the image path, ensuring images are tagged and pushed to the correct public repository.Added `registry-type: public` to the Amazon ECR login step and updated image paths to include the public alias. This ensures compatibility with public ECR repositories across all deploy-to-ecr workflows.