### PR TITLE
Add workflow_dispatch trigger to ECR deployment workflows

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image to ECR
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'


### PR DESCRIPTION
This enables manual triggering of the deployment workflows. The change provides greater flexibility for running the workflows outside of automatic tag pushes.