### PR TITLE
Update WebSecurityConfig error handling for consistent behavior

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -92,7 +92,7 @@ public class WebSecurityConfig {
                     return Mono.error(new InvalidCredentialsException());
                 }
             }
-            return Mono.error(new InvalidCredentialsException());
+            return Mono.empty();
         }
     }
 }


### PR DESCRIPTION
This pull request makes a small change to the authentication logic in `WebSecurityConfig.java`. Instead of returning an error when authentication fails, the code now returns an empty `Mono`, which changes how failed authentications are handled in the reactive security pipeline.