### PR TITLE
Develop

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image to ECR
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -92,7 +92,7 @@ public class WebSecurityConfig {
                     return Mono.error(new InvalidCredentialsException());
                 }
             }
-            return Mono.error(new InvalidCredentialsException());
+            return Mono.empty();
         }
     }
 }


### PR DESCRIPTION
This pull request makes a small but important change to the `WebSecurityConfig.java` file, specifically in the authentication logic. Now, instead of returning an error when no credentials are provided, the method returns an empty result, which can help prevent unnecessary error handling downstream.

- Changed the fallback behavior in `load(ServerWebExchange exchange)` to return `Mono.empty()` instead of an error when no credentials are present.