### PR TITLE
Update application.yaml to configure actuator base path and Swagger

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -20,6 +20,7 @@ aws:
 management:
   endpoints:
     web:
+      base-path: "/report/actuator"
       exposure:
         include: "health,prometheus"
   endpoint:
@@ -37,6 +38,15 @@ entrypoint:
     maxNumberOfMessages: 10
     visibilityTimeoutSeconds: 10
     numberOfThreads: 1
+
+springdoc:
+  api-docs:
+    info:
+      title: "Crediya Report API Microservice"
+      version: "1.0.0"
+      description: "This is the API for Crediya Report Microservice"
+  swagger-ui:
+    path: /report/swagger-ui.html
 
 security:
   jwt:


### PR DESCRIPTION
This pull request introduces configuration updates to the `application.yaml` file for the app-service, focusing on improving observability and API documentation setup. The most significant changes are the customization of actuator endpoint paths and the addition of OpenAPI/Swagger documentation configuration.

**Observability and API documentation configuration:**

* Changed the base path for actuator endpoints to `/report/actuator` to customize where management endpoints are exposed.
* Added `springdoc` configuration to enable OpenAPI documentation, including API metadata (title, version, description) and the path for Swagger UI (`/report/swagger-ui.html`).