### PR TITLE
Configure Swagger and API documentation paths

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ springdoc:
       title: "Crediya Report API Microservice"
       version: "1.0.0"
       description: "This is the API for Crediya Report Microservice"
+    path: /report/api-docs
   swagger-ui:
     path: /report/swagger-ui.html
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -23,17 +23,17 @@ public class ApiConstants {
         public static final String BASE_PATH = "/api/v1";
         public static final String REPORT_PATH = BASE_PATH + "/reportes";
         public static final String REPORT_BY_NAME_PATH = REPORT_PATH + "/{" + ApiParams.METRIC_NAME_PARAM + "}";
-        public static final String SWAGGER_PATH = "/swagger-ui.html";
+        public static final String SWAGGER_PATH = "/report/swagger-ui.html";
     }
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class ApiPathMatchers {
         //PERMIT ALL
-        public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
-        public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        public static final String API_DOCS_MATCHER = "/report/api-docs/**";
+        public static final String SWAGGER_UI_MATCHER = "/report/swagger-ui/**";
         //SUPER_USER
-        public static final String ACTUATOR_MATCHER = "/actuator/**";
-        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
+        public static final String ACTUATOR_MATCHER = "/report/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/report/actuator/health/**";
         //ADMIN
         public static final String REPORT_MATCHER = ApiPaths.REPORT_PATH +"/**";
     }


### PR DESCRIPTION
This pull request updates the API documentation and actuator endpoint paths to be namespaced under `/report` for the Crediya Report API Microservice. These changes ensure that Swagger UI, API docs, and actuator endpoints are consistently accessible via the `/report` prefix, improving clarity and avoiding potential path conflicts.

**API Documentation and Endpoint Path Updates:**

* Updated the OpenAPI documentation (`springdoc`) and Swagger UI paths in `application.yaml` to use `/report/api-docs` and `/report/swagger-ui.html` respectively.
* Changed constants in `ApiConstants.java` to reflect the new base paths for Swagger UI, API docs, and actuator endpoints, all now prefixed with `/report`. This includes updating path matchers for security configuration.