### PR TITLE
Hu/10 deploy producction

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -3,8 +3,8 @@ name: Build and Push Docker Image to ECR
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - "main"
 
 jobs:
   build-and-push:
@@ -42,8 +42,7 @@ jobs:
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/config/DynamoDBConfig.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/config/DynamoDBConfig.java
@@ -4,10 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.*;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
@@ -48,7 +45,7 @@ public class DynamoDBConfig {
     @Profile({"prod"})
     public DynamoDbAsyncClient amazonDynamoDBAsync(MetricPublisher publisher, @Value("${aws.region}") String region) {
         return DynamoDbAsyncClient.builder()
-                .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .credentialsProvider(ContainerCredentialsProvider.builder().build())
                 .region(Region.of(region))
                 .overrideConfiguration(o -> o.addMetricPublisher(publisher))
                 .build();


### PR DESCRIPTION
This pull request updates both the deployment workflow for Docker images and the AWS credentials provider for DynamoDB in production. The most important changes are grouped below:

**CI/CD Workflow Updates:**

* The GitHub Actions workflow in `.github/workflows/deploy-to-ecr.yml` is now triggered on pushes to the `main` branch instead of version tags, streamlining deployment to ECR.
* Docker image tagging in the workflow was updated to only push the `latest` tag when on the default branch, improving control over which images are marked as latest.

**AWS Credentials Provider Update:**

* In `DynamoDBConfig.java`, the production profile now uses `ContainerCredentialsProvider` instead of `WebIdentityTokenFileCredentialsProvider` for the DynamoDB async client, which is more suitable for containerized environments (e.g., ECS, EKS).

**Code Cleanup:**

* Unused AWS credentials provider imports were removed and replaced with a wildcard import for cleaner code in `DynamoDBConfig.java`.