### PR TITLE
Develop

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -3,8 +3,8 @@ name: Build and Push Docker Image to ECR
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - "main"
 
 jobs:
   build-and-push:
@@ -42,8 +42,7 @@ jobs:
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/config/DynamoDBConfig.java
+++ b/infrastructure/driven-adapters/dynamo-db/src/main/java/co/com/pragma/dynamodb/config/DynamoDBConfig.java
@@ -4,10 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.*;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
@@ -48,7 +45,7 @@ public class DynamoDBConfig {
     @Profile({"prod"})
     public DynamoDbAsyncClient amazonDynamoDBAsync(MetricPublisher publisher, @Value("${aws.region}") String region) {
         return DynamoDbAsyncClient.builder()
-                .credentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .credentialsProvider(ContainerCredentialsProvider.builder().build())
                 .region(Region.of(region))
                 .overrideConfiguration(o -> o.addMetricPublisher(publisher))
                 .build();


### PR DESCRIPTION
This pull request updates the deployment workflow and improves AWS credential management for DynamoDB. The most important changes are grouped below:

**Deployment Workflow Updates:**

* The GitHub Actions workflow for building and pushing Docker images to ECR now triggers on pushes to the `main` branch instead of on tags, aligning deployments with the main development branch.
* The Docker image tag configuration was updated to only apply the `latest` tag when building from the default branch, improving tagging accuracy and avoiding unnecessary `latest` tags on non-main branches.

**AWS Credential Management Improvements:**

* In the DynamoDB configuration (`DynamoDBConfig.java`), production credentials now use `ContainerCredentialsProvider` instead of `WebIdentityTokenFileCredentialsProvider`, which is more suitable for containerized environments such as ECS or EKS.
* Java imports in `DynamoDBConfig.java` were consolidated for clarity and maintainability by combining all AWS credentials imports into a single line.